### PR TITLE
Disable msGraph retries by default

### DIFF
--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -55,12 +55,15 @@ func NewAzureClient(ctx context.Context, clientID, clientSecret, tenantID, graph
 
 	usersClient := hamiltonMsgraph.NewUsersClient(tenantID)
 	usersClient.BaseClient.Authorizer = authorizer
+	usersClient.BaseClient.DisableRetries = true
 
 	servicePrincipalsClient := hamiltonMsgraph.NewServicePrincipalsClient(tenantID)
 	servicePrincipalsClient.BaseClient.Authorizer = authorizer
+	servicePrincipalsClient.BaseClient.DisableRetries = true
 
 	groupsClient := hamiltonMsgraph.NewGroupsClient(tenantID)
 	groupsClient.BaseClient.Authorizer = authorizer
+	groupsClient.BaseClient.DisableRetries = true
 
 	if graphFilter != "" {
 		graphFilter = fmt.Sprintf("startswith(displayName,'%s')", graphFilter)


### PR DESCRIPTION
This is new behaviour in the hamilton SDK documented here: https://github.com/manicminer/hamilton/releases/tag/v0.16.0