### PR TITLE
Update Ingress version to support Kubernetes v1.22+

### DIFF
--- a/charts/azad-kube-proxy/templates/ingress.yaml
+++ b/charts/azad-kube-proxy/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "azad-kube-proxy.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -16,6 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -32,10 +31,13 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - pathType: {{ default "Prefix" .pathType }}
+            path: {{ .path }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/azad-kube-proxy/values.yaml
+++ b/charts/azad-kube-proxy/values.yaml
@@ -76,6 +76,7 @@ service:
 
 ingress:
   enabled: false
+  ingrssClassName: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
This fixes issues installing to Kubernetes v1.22 clusters. This is also a breaking change as clusters running <v1.19 will not work.