### PR TITLE
Resolve Windows config generation handling

### DIFF
--- a/cmd/kubectl-azad-proxy/actions/generate.go
+++ b/cmd/kubectl-azad-proxy/actions/generate.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"os/user"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -46,11 +47,13 @@ func NewGenerateClient(ctx context.Context, c *cli.Context) (GenerateInterface, 
 		return nil, err
 	}
 
+	kubeConfig := filepath.Clean(c.String("kubeconfig"))
+
 	return &GenerateClient{
 		clusterName:        c.String("cluster-name"),
 		proxyURL:           *proxyURL,
 		resource:           c.String("resource"),
-		kubeConfig:         c.String("kubeconfig"),
+		kubeConfig:         kubeConfig,
 		tokenCache:         c.String("token-cache"),
 		overwrite:          c.Bool("overwrite"),
 		insecureSkipVerify: c.Bool("tls-insecure-skip-verify"),

--- a/cmd/kubectl-azad-proxy/actions/generate.go
+++ b/cmd/kubectl-azad-proxy/actions/generate.go
@@ -160,12 +160,12 @@ func (client *GenerateClient) Generate(ctx context.Context) error {
 	log := logr.FromContextOrDiscard(ctx)
 
 	kubeCfg, err := k8sclientcmd.LoadFromFile(client.kubeConfig)
-	if err != nil && !strings.Contains(err.Error(), "no such file or directory") {
+	if err != nil && !os.IsNotExist(err) {
 		log.V(1).Info("Unable to load kubeConfig", "error", err.Error(), "kubeConfig", client.kubeConfig)
 		return customerrors.New(customerrors.ErrorTypeKubeConfig, err)
 	}
 
-	if err != nil && strings.Contains(err.Error(), "no such file or directory") {
+	if err != nil && os.IsNotExist(err) {
 		kubeCfg = k8sclientcmdapi.NewConfig()
 	}
 

--- a/cmd/kubectl-azad-proxy/actions/generate.go
+++ b/cmd/kubectl-azad-proxy/actions/generate.go
@@ -48,17 +48,11 @@ func NewGenerateClient(ctx context.Context, c *cli.Context) (GenerateInterface, 
 		return nil, err
 	}
 
-	kubeConfig, err := getKubeConfig(c.String("kubeconfig"))
-	if err != nil {
-		log.V(1).Info("Unable to get the kube config", "error", err.Error())
-		return nil, err
-	}
-
 	return &GenerateClient{
 		clusterName:        c.String("cluster-name"),
 		proxyURL:           *proxyURL,
 		resource:           c.String("resource"),
-		kubeConfig:         kubeConfig,
+		kubeConfig:         filepath.Clean(c.String("kubeconfig")),
 		tokenCache:         c.String("token-cache"),
 		overwrite:          c.Bool("overwrite"),
 		insecureSkipVerify: c.Bool("tls-insecure-skip-verify"),
@@ -68,22 +62,6 @@ func NewGenerateClient(ctx context.Context, c *cli.Context) (GenerateInterface, 
 			excludeMSICredential:         c.Bool("exclude-msi-auth"),
 		},
 	}, nil
-}
-
-func getKubeConfig(path string) (string, error) {
-	kubeConfig := filepath.Clean(path)
-	dir := filepath.Dir(kubeConfig)
-	_, err := os.Stat(dir)
-	if !os.IsNotExist(err) {
-		return kubeConfig, err
-	}
-
-	err = os.MkdirAll(dir, 600)
-	if err != nil {
-		return "", err
-	}
-
-	return kubeConfig, nil
 }
 
 // GenerateFlags ...


### PR DESCRIPTION
This PR fixes an issue where Windows won't be able to create a kube config due to wrongfully handling os independent errors.

Fixes #560