### PR TITLE
kubectl plugin: change token cache behaviour

### DIFF
--- a/cmd/kubectl-azad-proxy/actions/generate.go
+++ b/cmd/kubectl-azad-proxy/actions/generate.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"time"

--- a/cmd/kubectl-azad-proxy/actions/generate.go
+++ b/cmd/kubectl-azad-proxy/actions/generate.go
@@ -67,9 +67,12 @@ func NewGenerateClient(ctx context.Context, c *cli.Context) (GenerateInterface, 
 }
 
 // GenerateFlags ...
-func GenerateFlags(ctx context.Context) []cli.Flag {
-	// FIXME: Make sure this can fail
-	usr, _ := user.Current()
+func GenerateFlags(ctx context.Context) ([]cli.Flag, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+
 	return []cli.Flag{
 		&cli.StringFlag{
 			Name:     "cluster-name",
@@ -131,7 +134,7 @@ func GenerateFlags(ctx context.Context) []cli.Flag {
 			EnvVars: []string{"EXCLUDE_MSI_AUTH"},
 			Value:   true,
 		},
-	}
+	}, nil
 }
 
 // Generate ...

--- a/cmd/kubectl-azad-proxy/actions/generate.go
+++ b/cmd/kubectl-azad-proxy/actions/generate.go
@@ -154,21 +154,21 @@ func (client *GenerateClient) Generate(ctx context.Context) error {
 	var found bool
 	_, found = kubeCfg.Clusters[client.clusterName]
 	if found && !client.overwrite {
-		err := fmt.Errorf("Cluster (%s) was found in config (%s) but overwrite is %t", client.clusterName, client.kubeConfig, client.overwrite)
+		err := fmt.Errorf("cluster (%s) was found in config (%s) but overwrite is %t", client.clusterName, client.kubeConfig, client.overwrite)
 		log.V(1).Info("Overwrite is not enabled", "error", err.Error())
 		return customerrors.New(customerrors.ErrorTypeOverwriteConfig, err)
 	}
 
 	_, found = kubeCfg.Contexts[client.clusterName]
 	if found && !client.overwrite {
-		err := fmt.Errorf("Context (%s) was found in config (%s) but overwrite is %t", client.clusterName, client.kubeConfig, client.overwrite)
+		err := fmt.Errorf("context (%s) was found in config (%s) but overwrite is %t", client.clusterName, client.kubeConfig, client.overwrite)
 		log.V(1).Info("Overwrite is not enabled", "error", err.Error())
 		return customerrors.New(customerrors.ErrorTypeOverwriteConfig, err)
 	}
 
 	_, found = kubeCfg.AuthInfos[client.clusterName]
 	if found && !client.overwrite {
-		err := fmt.Errorf("User (%s) was found in config (%s) but overwrite is %t", client.clusterName, client.kubeConfig, client.overwrite)
+		err := fmt.Errorf("user (%s) was found in config (%s) but overwrite is %t", client.clusterName, client.kubeConfig, client.overwrite)
 		log.V(1).Info("Overwrite is not enabled", "error", err.Error())
 		return customerrors.New(customerrors.ErrorTypeOverwriteConfig, err)
 	}

--- a/cmd/kubectl-azad-proxy/actions/generate.go
+++ b/cmd/kubectl-azad-proxy/actions/generate.go
@@ -68,7 +68,7 @@ func NewGenerateClient(ctx context.Context, c *cli.Context) (GenerateInterface, 
 
 // GenerateFlags ...
 func GenerateFlags(ctx context.Context) ([]cli.Flag, error) {
-	usr, err := user.Current()
+	osUserHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func GenerateFlags(ctx context.Context) ([]cli.Flag, error) {
 			Name:     "kubeconfig",
 			Usage:    "The path of the Kubernetes Config",
 			EnvVars:  []string{"KUBECONFIG"},
-			Value:    fmt.Sprintf("%s/.kube/config", usr.HomeDir),
+			Value:    fmt.Sprintf("%s/.kube/config", osUserHomeDir),
 			Required: false,
 		},
 		&cli.StringFlag{

--- a/cmd/kubectl-azad-proxy/actions/generate_test.go
+++ b/cmd/kubectl-azad-proxy/actions/generate_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 	k8sclientcmd "k8s.io/client-go/tools/clientcmd"
 )
@@ -129,7 +130,7 @@ func TestMergeGenerateClient(t *testing.T) {
 		proxyURL:           getURL("https://www.google.com"),
 		resource:           "https://fake",
 		kubeConfig:         "/tmp/kubeconfig",
-		tokenCache:         "/tmp/tokencache",
+		tokenCacheDir:      "/tmp/tokencache",
 		overwrite:          false,
 		insecureSkipVerify: false,
 		defaultAzureCredentialOptions: defaultAzureCredentialOptions{
@@ -144,7 +145,7 @@ func TestMergeGenerateClient(t *testing.T) {
 		proxyURL:           getURL("https://www.example.com"),
 		resource:           "https://fake2",
 		kubeConfig:         "/tmp2/kubeconfig",
-		tokenCache:         "/tmp2/tokencache",
+		tokenCacheDir:      "/tmp2/tokencache",
 		overwrite:          true,
 		insecureSkipVerify: true,
 	})
@@ -161,8 +162,8 @@ func TestMergeGenerateClient(t *testing.T) {
 	if client.kubeConfig != "/tmp2/kubeconfig" {
 		t.Errorf("Expected client.kubeConfig to be '/tmp2/kubeconfig' but was: %s", client.kubeConfig)
 	}
-	if client.tokenCache != "/tmp2/tokencache" {
-		t.Errorf("Expected client.tokenCache to be '/tmp2/tokencache' but was: %s", client.tokenCache)
+	if client.tokenCacheDir != "/tmp2/tokencache" {
+		t.Errorf("Expected client.tokenCache to be '/tmp2/tokencache' but was: %s", client.tokenCacheDir)
 	}
 	if client.overwrite != true {
 		t.Errorf("Expected client.overwrite to be 'true' but was: %t", client.overwrite)
@@ -174,12 +175,12 @@ func TestMergeGenerateClient(t *testing.T) {
 
 func TestGenerate(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
-	curDir, err := os.Getwd()
-	if err != nil {
-		t.Errorf("Expected err to be nil: %q", err)
-	}
-	tokenCacheFile := fmt.Sprintf("%s/../../../tmp/test-cached-tokens-generate", curDir)
-	kubeConfigFile := fmt.Sprintf("%s/../../../tmp/test-generate-kubeconfig", curDir)
+
+	tmpDir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	tokenCacheDir := tmpDir
+	kubeConfigFile := fmt.Sprintf("%s/kubeconfig", tmpDir)
 	defer deleteFile(t, kubeConfigFile)
 
 	client := &GenerateClient{
@@ -187,7 +188,7 @@ func TestGenerate(t *testing.T) {
 		proxyURL:           getURL("https://www.google.com"),
 		resource:           "https://fake",
 		kubeConfig:         kubeConfigFile,
-		tokenCache:         tokenCacheFile,
+		tokenCacheDir:      tokenCacheDir,
 		overwrite:          false,
 		insecureSkipVerify: false,
 		defaultAzureCredentialOptions: defaultAzureCredentialOptions{

--- a/cmd/kubectl-azad-proxy/actions/generate_test.go
+++ b/cmd/kubectl-azad-proxy/actions/generate_test.go
@@ -19,6 +19,9 @@ func TestNewGenerateClient(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	client := &GenerateClient{}
 
+	generateFlags, err := GenerateFlags(ctx)
+	require.NoError(t, err)
+
 	app := &cli.App{
 		Name:  "test",
 		Usage: "test",
@@ -27,7 +30,7 @@ func TestNewGenerateClient(t *testing.T) {
 				Name:    "test",
 				Aliases: []string{"t"},
 				Usage:   "test",
-				Flags:   GenerateFlags(ctx),
+				Flags:   generateFlags,
 				Action: func(c *cli.Context) error {
 					ci, err := NewGenerateClient(ctx, c)
 					if err != nil {

--- a/cmd/kubectl-azad-proxy/actions/login.go
+++ b/cmd/kubectl-azad-proxy/actions/login.go
@@ -60,7 +60,7 @@ func getTokenCacheDirectory(tokenCacheDirectory, kubeConfig string) string {
 
 // LoginFlags ...
 func LoginFlags(ctx context.Context) ([]cli.Flag, error) {
-	usr, err := user.Current()
+	osUserHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func LoginFlags(ctx context.Context) ([]cli.Flag, error) {
 			Name:     "kubeconfig",
 			Usage:    "The path of the Kubernetes Config",
 			EnvVars:  []string{"KUBECONFIG"},
-			Value:    fmt.Sprintf("%s/.kube/config", usr.HomeDir),
+			Value:    fmt.Sprintf("%s/.kube/config", osUserHomeDir),
 			Required: false,
 		},
 		&cli.BoolFlag{

--- a/cmd/kubectl-azad-proxy/actions/login.go
+++ b/cmd/kubectl-azad-proxy/actions/login.go
@@ -59,9 +59,12 @@ func getTokenCacheDirectory(tokenCacheDirectory, kubeConfig string) string {
 }
 
 // LoginFlags ...
-func LoginFlags(ctx context.Context) []cli.Flag {
-	// FIXME: Make sure this can fail
-	usr, _ := user.Current()
+func LoginFlags(ctx context.Context) ([]cli.Flag, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+
 	return []cli.Flag{
 		&cli.StringFlag{
 			Name:     "cluster-name",
@@ -105,7 +108,7 @@ func LoginFlags(ctx context.Context) []cli.Flag {
 			EnvVars: []string{"EXCLUDE_MSI_AUTH"},
 			Value:   true,
 		},
-	}
+	}, nil
 }
 
 // Login ...

--- a/cmd/kubectl-azad-proxy/actions/login.go
+++ b/cmd/kubectl-azad-proxy/actions/login.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/user"
+	"os"
 	"path/filepath"
 
 	"github.com/urfave/cli/v2"
@@ -40,9 +40,9 @@ func NewLoginClient(ctx context.Context, c *cli.Context) (LoginInterface, error)
 	}, nil
 }
 
-func getTokenCacheDirectory(tokenCacheDirectory, kubeConfig string) string {
-	if tokenCacheDirectory != "" {
-		return filepath.Clean(tokenCacheDirectory)
+func getTokenCacheDirectory(tokenCacheDir, kubeConfig string) string {
+	if tokenCacheDir != "" {
+		return filepath.Clean(tokenCacheDir)
 	}
 
 	if kubeConfig != "" {
@@ -50,9 +50,9 @@ func getTokenCacheDirectory(tokenCacheDirectory, kubeConfig string) string {
 	}
 
 	userHomeDir := "~"
-	usr, err := user.Current()
+	osUserHomeDir, err := os.UserHomeDir()
 	if err == nil {
-		userHomeDir = usr.HomeDir
+		userHomeDir = osUserHomeDir
 	}
 
 	return filepath.Clean(fmt.Sprintf("%s/.kube", userHomeDir))

--- a/cmd/kubectl-azad-proxy/actions/login_test.go
+++ b/cmd/kubectl-azad-proxy/actions/login_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"

--- a/cmd/kubectl-azad-proxy/actions/login_test.go
+++ b/cmd/kubectl-azad-proxy/actions/login_test.go
@@ -21,6 +21,9 @@ func TestNewLoginClient(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	client := &LoginClient{}
 
+	loginFlags, err := LoginFlags(ctx)
+	require.NoError(t, err)
+
 	app := &cli.App{
 		Name:  "test",
 		Usage: "test",
@@ -29,7 +32,7 @@ func TestNewLoginClient(t *testing.T) {
 				Name:    "test",
 				Aliases: []string{"t"},
 				Usage:   "test",
-				Flags:   LoginFlags(ctx),
+				Flags:   loginFlags,
 				Action: func(c *cli.Context) error {
 					ci, err := NewLoginClient(ctx, c)
 					if err != nil {

--- a/cmd/kubectl-azad-proxy/actions/login_test.go
+++ b/cmd/kubectl-azad-proxy/actions/login_test.go
@@ -212,7 +212,7 @@ func TestLogin(t *testing.T) {
 }
 
 func TestGetTokenCacheDirectory(t *testing.T) {
-	usr, err := user.Current()
+	osUserHomeDir, err := os.UserHomeDir()
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -225,7 +225,7 @@ func TestGetTokenCacheDirectory(t *testing.T) {
 			testDescription: "all inputs empty strings",
 			tokenCacheDir:   "",
 			kubeConfig:      "",
-			expectedResult:  fmt.Sprintf("%s/.kube", usr.HomeDir),
+			expectedResult:  fmt.Sprintf("%s/.kube", osUserHomeDir),
 		},
 		{
 			testDescription: "kubeConfig set but not tokenCachePath",

--- a/cmd/kubectl-azad-proxy/actions/menu.go
+++ b/cmd/kubectl-azad-proxy/actions/menu.go
@@ -42,11 +42,16 @@ func NewMenuClient(ctx context.Context, c *cli.Context) (MenuInterface, error) {
 }
 
 // MenuFlags ...
-func MenuFlags(ctx context.Context) []cli.Flag {
-	flags := mergeFlags(DiscoverFlags(ctx), GenerateFlags(ctx))
+func MenuFlags(ctx context.Context) ([]cli.Flag, error) {
+	generateFlags, err := GenerateFlags(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	flags := mergeFlags(DiscoverFlags(ctx), generateFlags)
 	flags = unrequireFlags(flags)
 
-	return flags
+	return flags, nil
 }
 
 // Menu ...

--- a/cmd/kubectl-azad-proxy/actions/menu_test.go
+++ b/cmd/kubectl-azad-proxy/actions/menu_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 	"github.com/xenitab/azad-kube-proxy/cmd/kubectl-azad-proxy/customerrors"
 )
@@ -17,6 +18,9 @@ func TestNewMenuClient(t *testing.T) {
 	restoreAzureCLIAuth := tempChangeEnv("EXCLUDE_AZURE_CLI_AUTH", "true")
 	defer restoreAzureCLIAuth()
 
+	menuFlags, err := MenuFlags(ctx)
+	require.NoError(t, err)
+
 	app := &cli.App{
 		Name:  "test",
 		Usage: "test",
@@ -25,7 +29,7 @@ func TestNewMenuClient(t *testing.T) {
 				Name:    "test",
 				Aliases: []string{"t"},
 				Usage:   "test",
-				Flags:   MenuFlags(ctx),
+				Flags:   menuFlags,
 				Action: func(c *cli.Context) error {
 					_, err := NewMenuClient(ctx, c)
 					if err != nil {
@@ -39,7 +43,7 @@ func TestNewMenuClient(t *testing.T) {
 
 	app.Writer = &bytes.Buffer{}
 	app.ErrWriter = &bytes.Buffer{}
-	err := app.Run([]string{"fake-binary", "test"})
+	err = app.Run([]string{"fake-binary", "test"})
 	if err != nil {
 		t.Errorf("Expected err to be nil: %q", err)
 	}

--- a/cmd/kubectl-azad-proxy/actions/token.go
+++ b/cmd/kubectl-azad-proxy/actions/token.go
@@ -61,6 +61,7 @@ type Tokens struct {
 	defaultAzureCredentialOptions defaultAzureCredentialOptions
 }
 
+// nolint: gosec
 const tokenCacheFileName = "azad-proxy.json"
 
 // NewTokens returns a TokensInterface or error

--- a/cmd/kubectl-azad-proxy/actions/token.go
+++ b/cmd/kubectl-azad-proxy/actions/token.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
+	"path/filepath"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -49,7 +49,7 @@ func (t *Token) Valid() bool {
 
 // TokensInterface is the interface for the Tokens struct
 type TokensInterface interface {
-	GetPath() string
+	GetTokenCacheFilePath() string
 	GetToken(ctx context.Context, name string, resource string) (Token, error)
 	SetToken(ctx context.Context, name string, token Token) error
 }
@@ -57,41 +57,37 @@ type TokensInterface interface {
 // Tokens contains the token struct
 type Tokens struct {
 	cachedTokens                  map[string]Token
-	path                          string
+	tokenCacheFilePath            string
 	defaultAzureCredentialOptions defaultAzureCredentialOptions
 }
 
-// NewTokens returns a TokensInterface or error
-func NewTokens(ctx context.Context, path string, defaultAzureCredentialOptions defaultAzureCredentialOptions) (TokensInterface, error) {
-	log := logr.FromContextOrDiscard(ctx)
+const tokenCacheFileName = "azad-proxy.json"
 
-	if strings.HasPrefix(path, "~/") {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			log.V(1).Info("Unable to get user home directory", "error", err.Error())
-		}
-		path = strings.Replace(path, "~/", fmt.Sprintf("%s/", homeDir), 1)
-	}
+// NewTokens returns a TokensInterface or error
+func NewTokens(ctx context.Context, tokenCacheDir string, defaultAzureCredentialOptions defaultAzureCredentialOptions) (TokensInterface, error) {
+	log := logr.FromContextOrDiscard(ctx)
+	tokenCacheFilePath := filepath.Clean(fmt.Sprintf("%s/%s", tokenCacheDir, tokenCacheFileName))
 
 	t := Tokens{
 		cachedTokens:                  make(map[string]Token),
-		path:                          path,
+		tokenCacheFilePath:            tokenCacheFilePath,
 		defaultAzureCredentialOptions: defaultAzureCredentialOptions,
 	}
-	cacheFileExists := fileExists(path)
+	cacheFileExists := fileExists(tokenCacheFilePath)
 
 	if !cacheFileExists {
 		return t, nil
 	}
 
-	fileContent, err := getFileContent(path)
+	fileContent, err := getFileContent(tokenCacheFilePath)
 	if err != nil {
-		log.V(1).Info("Unable to get file content", "error", err.Error(), "path", path)
+		log.V(1).Info("Unable to get file content", "error", err.Error(), "path", tokenCacheFilePath)
 		return nil, customerrors.New(customerrors.ErrorTypeTokenCache, err)
 	}
 
 	err = json.Unmarshal(fileContent, &t.cachedTokens)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Received the following error unmarshalling: %v", err)
 		log.V(1).Info("Unable to unmarshal cachedTokens", "error", err.Error())
 		return nil, customerrors.New(customerrors.ErrorTypeTokenCache, err)
 	}
@@ -99,9 +95,9 @@ func NewTokens(ctx context.Context, path string, defaultAzureCredentialOptions d
 	return t, nil
 }
 
-// GetPath returns the path where the cached tokens are stored
-func (t Tokens) GetPath() string {
-	return t.path
+// GetTokenCacheFilePath returns the path where the cached tokens are stored
+func (t Tokens) GetTokenCacheFilePath() string {
+	return t.tokenCacheFilePath
 }
 
 // GetToken ...
@@ -158,9 +154,9 @@ func (t Tokens) SetToken(ctx context.Context, name string, token Token) error {
 		return customerrors.New(customerrors.ErrorTypeTokenCache, err)
 	}
 
-	err = os.WriteFile(t.path, fileContents, 0600)
+	err = os.WriteFile(t.tokenCacheFilePath, fileContents, 0600)
 	if err != nil {
-		log.V(1).Info("Unable to write token cache file", "error", err.Error(), "path", t.path)
+		log.V(1).Info("Unable to write token cache file", "error", err.Error(), "path", t.tokenCacheFilePath)
 		return customerrors.New(customerrors.ErrorTypeTokenCache, err)
 	}
 

--- a/cmd/kubectl-azad-proxy/actions/token.go
+++ b/cmd/kubectl-azad-proxy/actions/token.go
@@ -88,7 +88,6 @@ func NewTokens(ctx context.Context, tokenCacheDir string, defaultAzureCredential
 
 	err = json.Unmarshal(fileContent, &t.cachedTokens)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Received the following error unmarshalling: %v", err)
 		log.V(1).Info("Unable to unmarshal cachedTokens", "error", err.Error())
 		return nil, customerrors.New(customerrors.ErrorTypeTokenCache, err)
 	}

--- a/cmd/kubectl-azad-proxy/actions/token_test.go
+++ b/cmd/kubectl-azad-proxy/actions/token_test.go
@@ -107,11 +107,15 @@ func TestGetToken(t *testing.T) {
 		excludeMSICredential:         true,
 	}
 
-	curDir, err := os.Getwd()
-	if err != nil {
-		t.Errorf("Expected err to be nil: %q", err)
-	}
-	fakeFile := fmt.Sprintf("%s/../../../tmp/test-cached-tokens-fake", curDir)
+	tmpDir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	fakeDir := fmt.Sprintf("%s/fake", tmpDir)
+	err = os.Mkdir(fakeDir, 0700)
+	require.NoError(t, err)
+
+	fakeFile := fmt.Sprintf("%s/%s", fakeDir, tokenCacheFileName)
 	fakeToken := make(map[string]Token)
 	fakeToken["fake-cluster-1"] = Token{
 		Token:               "abc123",
@@ -124,22 +128,26 @@ func TestGetToken(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected err to be nil: %q", err)
 	}
-	defer deleteFile(t, fakeFile)
 
-	fakeTokens, err := NewTokens(ctx, fakeFile, creds)
+	fakeTokens, err := NewTokens(ctx, fakeDir, creds)
 	if err != nil {
 		t.Errorf("Expected err to be nil: %q", err)
 	}
 
-	realFile := fmt.Sprintf("%s/../../../tmp/test-cached-tokens-real", curDir)
-	realTokens, err := NewTokens(ctx, realFile, creds)
+	realDir := fmt.Sprintf("%s/real", tmpDir)
+	err = os.Mkdir(realDir, 0700)
+	require.NoError(t, err)
+
+	realTokens, err := NewTokens(ctx, realDir, creds)
 	if err != nil {
 		t.Errorf("Expected err to be nil: %q", err)
 	}
-	defer deleteFile(t, realFile)
 
-	realFalseFile := fmt.Sprintf("%s/../../../tmp/test-cached-tokens-realfalse", curDir)
-	realFalseTokens, err := NewTokens(ctx, realFalseFile, credsFalse)
+	realFalseDir := fmt.Sprintf("%s/realfalse", tmpDir)
+	err = os.Mkdir(realFalseDir, 0700)
+	require.NoError(t, err)
+
+	realFalseTokens, err := NewTokens(ctx, realFalseDir, credsFalse)
 	if err != nil {
 		t.Errorf("Expected err to be nil: %q", err)
 	}

--- a/cmd/kubectl-azad-proxy/actions/token_test.go
+++ b/cmd/kubectl-azad-proxy/actions/token_test.go
@@ -10,107 +10,68 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewTokens(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 
-	fakeHomeDir := "/home/test-user"
-	restoreHomeDir := tempChangeEnv("HOME", fakeHomeDir)
-	defer restoreHomeDir()
-
-	defaultAzureCredentialOptions := defaultAzureCredentialOptions{
-		excludeAzureCLICredential:    false,
-		excludeEnvironmentCredential: false,
-		excludeMSICredential:         false,
+	opts := defaultAzureCredentialOptions{
+		excludeAzureCLICredential:    true,
+		excludeEnvironmentCredential: true,
+		excludeMSICredential:         true,
 	}
 
-	cases := []struct {
-		path                string
-		expectedErrContains string
-		expectedPath        string
-	}{
-		{
-			path:                "~/test",
-			expectedErrContains: "",
-			expectedPath:        fmt.Sprintf("%s/test", fakeHomeDir),
-		},
-		{
-			path:                "~/.kube/abc",
-			expectedErrContains: "",
-			expectedPath:        fmt.Sprintf("%s/.kube/abc", fakeHomeDir),
-		},
-		{
-			path:                "/home/test2/.kube/abc",
-			expectedErrContains: "",
-			expectedPath:        "/home/test2/.kube/abc",
-		},
-	}
+	t.Run("cache file doesn't exist", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
 
-	for _, c := range cases {
-		tokens, err := NewTokens(ctx, c.path, defaultAzureCredentialOptions)
-		if err != nil && c.expectedErrContains == "" {
-			t.Errorf("Expected err to be nil: %q", err)
-		}
-
-		if err == nil && c.expectedErrContains != "" {
-			t.Errorf("Expected err to contain '%s' but was nil", c.expectedErrContains)
-		}
-
-		if err != nil && c.expectedErrContains != "" {
-			if !strings.Contains(err.Error(), c.expectedErrContains) {
-				t.Errorf("Expected err to contain '%s' but was: %q", c.expectedErrContains, err)
-			}
-		}
-
-		if !strings.Contains(tokens.GetPath(), c.expectedPath) {
-			t.Errorf("Expected path to be '%s' but was: %s", c.expectedPath, tokens.GetPath())
-		}
-	}
-
-	curDir, err := os.Getwd()
-	if err != nil {
-		t.Errorf("Expected err to be nil: %q", err)
-	}
-	fakeFile := fmt.Sprintf("%s/../../../tmp/test-cached-tokens", curDir)
-	fakeToken := make(map[string]Token)
-	fakeToken["test"] = Token{
-		Token:               "abc123",
-		ExpirationTimestamp: time.Now().Add(1 * time.Hour),
-		Resource:            "https://fake-resource",
-		Name:                "test",
-	}
-
-	err = createCacheFile(fakeFile, fakeToken)
-	if err != nil {
-		t.Errorf("Expected err to be nil: %q", err)
-	}
-	defer deleteFile(t, fakeFile)
-
-	_, err = NewTokens(ctx, fakeFile, defaultAzureCredentialOptions)
-	if err != nil {
-		t.Errorf("Expected err to be nil: %q", err)
-	}
-
-	fakeFileErr := fmt.Sprintf("%s/../../../tmp/test-cached-tokens-err", curDir)
-	fakeTokenErr := make(map[string]struct {
-		FakeToken bool `json:"token"`
+		_, err = NewTokens(ctx, tmpDir, opts)
+		require.NoError(t, err)
 	})
-	fakeTokenErr["test"] = struct {
-		FakeToken bool `json:"token"`
-	}{
-		FakeToken: true,
-	}
-	err = createCacheFile(fakeFileErr, fakeTokenErr)
-	if err != nil {
-		t.Errorf("Expected err to be nil: %q", err)
-	}
-	defer deleteFile(t, fakeFileErr)
 
-	_, err = NewTokens(ctx, fakeFileErr, defaultAzureCredentialOptions)
-	if !strings.Contains(err.Error(), "Token cache error: ") {
-		t.Errorf("Expected err contain 'Token cache error: ' but was: %q", err)
-	}
+	t.Run("cache exists but can't read it", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		tmpFilePath := fmt.Sprintf("%s/%s", tmpDir, tokenCacheFileName)
+		_, err = os.Create(tmpFilePath)
+		require.NoError(t, err)
+
+		err = os.Chmod(tmpFilePath, 0000)
+		require.NoError(t, err)
+
+		_, err = NewTokens(ctx, tmpDir, opts)
+		require.ErrorContains(t, err, "Token cache error: ")
+	})
+
+	t.Run("cache exists but wrong format", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		tmpFilePath := fmt.Sprintf("%s/%s", tmpDir, tokenCacheFileName)
+		err = os.WriteFile(tmpFilePath, []byte("[]"), 0600)
+		require.NoError(t, err)
+
+		_, err = NewTokens(ctx, tmpDir, opts)
+		require.ErrorContains(t, err, "Token cache error: ")
+	})
+
+	t.Run("cache exists", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		tmpFilePath := fmt.Sprintf("%s/%s", tmpDir, tokenCacheFileName)
+		err = os.WriteFile(tmpFilePath, []byte("{}"), 0600)
+		require.NoError(t, err)
+
+		_, err = NewTokens(ctx, tmpDir, opts)
+		require.NoError(t, err)
+	})
 }
 
 func TestGetToken(t *testing.T) {


### PR DESCRIPTION
Now we will pass a directory path instead of the actual file to NewToken(), we also default to the same path as the environment variable KUBECONFIG if it's defined.

We also remove a where we check the user home directory in a better way to support more than just Linux.

Fixes #582 