### PR TITLE
refactor tests to use require

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
     - gocyclo
     - misspell
     - gosec
+    - thelper
 
 linters-settings:
   gocyclo:

--- a/cmd/azad-kube-proxy/main_test.go
+++ b/cmd/azad-kube-proxy/main_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCIRequirements(t *testing.T) {
-	ciEnvVar := getEnvOrSkip(t, "CI")
+	ciEnvVar := testGetEnvOrSkip(t, "CI")
 	if ciEnvVar != "true" {
 		t.Skipf("CI environment variable not set to true: %s", ciEnvVar)
 	}
@@ -22,21 +24,23 @@ func TestCIRequirements(t *testing.T) {
 	}
 
 	for _, envVar := range reqEnvVars {
-		getEnvOrError(t, envVar)
+		testGetEnvOrError(t, envVar)
 	}
 
 }
 
-func getEnvOrError(t *testing.T, envVar string) string {
+func testGetEnvOrError(t *testing.T, envVar string) string {
+	t.Helper()
+
 	v := os.Getenv(envVar)
-	if v == "" {
-		t.Errorf("%s environment variable is required by CI.", envVar)
-	}
+	require.NotEmpty(t, v)
 
 	return v
 }
 
-func getEnvOrSkip(t *testing.T, envVar string) string {
+func testGetEnvOrSkip(t *testing.T, envVar string) string {
+	t.Helper()
+
 	v := os.Getenv(envVar)
 	if v == "" {
 		t.Skipf("%s environment variable is empty, skipping.", envVar)

--- a/cmd/kubectl-azad-proxy/actions/discover_test.go
+++ b/cmd/kubectl-azad-proxy/actions/discover_test.go
@@ -92,18 +92,18 @@ func TestNewDiscoverClient(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		client = &DiscoverClient{}
 		c.cliApp.Writer = &c.outBuffer
 		c.cliApp.ErrWriter = &c.errBuffer
 		err := c.cliApp.Run(c.args)
 
 		if c.expectedErrContains != "" {
 			require.ErrorContains(t, err, c.expectedErrContains)
-		} else {
-			require.NoError(t, err)
-			require.Equal(t, c.expectedConfig.outputType, client.outputType)
+			continue
 		}
 
-		client = &DiscoverClient{}
+		require.NoError(t, err)
+		require.Equal(t, c.expectedConfig.outputType, client.outputType)
 	}
 }
 

--- a/cmd/kubectl-azad-proxy/actions/discover_test.go
+++ b/cmd/kubectl-azad-proxy/actions/discover_test.go
@@ -15,7 +15,7 @@ func TestNewDiscoverClient(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	client := &DiscoverClient{}
 
-	restoreAzureCLIAuth := tempChangeEnv("EXCLUDE_AZURE_CLI_AUTH", "true")
+	restoreAzureCLIAuth := testTempChangeEnv(t, "EXCLUDE_AZURE_CLI_AUTH", "true")
 	defer restoreAzureCLIAuth()
 
 	app := &cli.App{
@@ -108,10 +108,10 @@ func TestNewDiscoverClient(t *testing.T) {
 }
 
 func TestDiscover(t *testing.T) {
-	tenantID := getEnvOrSkip(t, "TENANT_ID")
-	clientID := getEnvOrSkip(t, "CLIENT_ID")
-	clientSecret := getEnvOrSkip(t, "CLIENT_SECRET")
-	resource := getEnvOrSkip(t, "TEST_USER_SP_RESOURCE")
+	tenantID := testGetEnvOrSkip(t, "TENANT_ID")
+	clientID := testGetEnvOrSkip(t, "CLIENT_ID")
+	clientSecret := testGetEnvOrSkip(t, "CLIENT_SECRET")
+	resource := testGetEnvOrSkip(t, "TEST_USER_SP_RESOURCE")
 
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 
@@ -181,9 +181,9 @@ func TestGetDiscoverData(t *testing.T) {
 		{
 			clusterApps: []hamiltonMsgraph.Application{
 				{
-					DisplayName:    toStringPtr("fake"),
-					IdentifierUris: toStringArrayPtr([]string{"https://fake"}),
-					Tags:           toStringArrayPtr([]string{"azad-kube-proxy"}),
+					DisplayName:    testToPtr(t, "fake"),
+					IdentifierUris: testToPtr(t, []string{"https://fake"}),
+					Tags:           testToPtr(t, []string{"azad-kube-proxy"}),
 				},
 			},
 			expectedOutput: []discover{
@@ -197,14 +197,14 @@ func TestGetDiscoverData(t *testing.T) {
 		{
 			clusterApps: []hamiltonMsgraph.Application{
 				{
-					DisplayName:    toStringPtr("fake"),
-					IdentifierUris: toStringArrayPtr([]string{"https://fake"}),
-					Tags:           toStringArrayPtr([]string{"azad-kube-proxy"}),
+					DisplayName:    testToPtr(t, "fake"),
+					IdentifierUris: testToPtr(t, []string{"https://fake"}),
+					Tags:           testToPtr(t, []string{"azad-kube-proxy"}),
 				},
 				{
-					DisplayName:    toStringPtr("fake2"),
-					IdentifierUris: toStringArrayPtr([]string{"https://fake2"}),
-					Tags:           toStringArrayPtr([]string{"azad-kube-proxy"}),
+					DisplayName:    testToPtr(t, "fake2"),
+					IdentifierUris: testToPtr(t, []string{"https://fake2"}),
+					Tags:           testToPtr(t, []string{"azad-kube-proxy"}),
 				},
 			},
 			expectedOutput: []discover{
@@ -223,9 +223,9 @@ func TestGetDiscoverData(t *testing.T) {
 		{
 			clusterApps: []hamiltonMsgraph.Application{
 				{
-					DisplayName:    toStringPtr("fake"),
-					IdentifierUris: toStringArrayPtr([]string{"https://fake"}),
-					Tags:           toStringArrayPtr([]string{"azad-kube-proxy", "cluster_name:newfake"}),
+					DisplayName:    testToPtr(t, "fake"),
+					IdentifierUris: testToPtr(t, []string{"https://fake"}),
+					Tags:           testToPtr(t, []string{"azad-kube-proxy", "cluster_name:newfake"}),
 				},
 			},
 			expectedOutput: []discover{
@@ -239,14 +239,14 @@ func TestGetDiscoverData(t *testing.T) {
 		{
 			clusterApps: []hamiltonMsgraph.Application{
 				{
-					DisplayName:    toStringPtr("fake"),
-					IdentifierUris: toStringArrayPtr([]string{"https://fake"}),
-					Tags:           toStringArrayPtr([]string{"azad-kube-proxy", "proxy_url:https://newfake"}),
+					DisplayName:    testToPtr(t, "fake"),
+					IdentifierUris: testToPtr(t, []string{"https://fake"}),
+					Tags:           testToPtr(t, []string{"azad-kube-proxy", "proxy_url:https://newfake"}),
 				},
 				{
-					DisplayName:    toStringPtr("fake"),
-					IdentifierUris: toStringArrayPtr([]string{"https://fake"}),
-					Tags:           toStringArrayPtr([]string{"azad-kube-proxy", "cluster_name:newfake2", "proxy_url:https://newfake2"}),
+					DisplayName:    testToPtr(t, "fake"),
+					IdentifierUris: testToPtr(t, []string{"https://fake"}),
+					Tags:           testToPtr(t, []string{"azad-kube-proxy", "cluster_name:newfake2", "proxy_url:https://newfake2"}),
 				},
 			},
 			expectedOutput: []discover{
@@ -265,9 +265,9 @@ func TestGetDiscoverData(t *testing.T) {
 		{
 			clusterApps: []hamiltonMsgraph.Application{
 				{
-					DisplayName:    toStringPtr("fake"),
-					IdentifierUris: toStringArrayPtr([]string{"https://fake"}),
-					Tags:           toStringArrayPtr([]string{"azad-kube-proxy", "fake"}),
+					DisplayName:    testToPtr(t, "fake"),
+					IdentifierUris: testToPtr(t, []string{"https://fake"}),
+					Tags:           testToPtr(t, []string{"azad-kube-proxy", "fake"}),
 				},
 			},
 			expectedOutput: []discover{
@@ -290,10 +290,8 @@ func TestGetDiscoverData(t *testing.T) {
 	}
 }
 
-func toStringPtr(s string) *string {
-	return &s
-}
+func testToPtr[T any](t *testing.T, s T) *T {
+	t.Helper()
 
-func toStringArrayPtr(s []string) *[]string {
 	return &s
 }

--- a/cmd/kubectl-azad-proxy/actions/generate_test.go
+++ b/cmd/kubectl-azad-proxy/actions/generate_test.go
@@ -91,20 +91,20 @@ func TestNewGenerateClient(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		client = &GenerateClient{}
 		c.cliApp.Writer = &c.outBuffer
 		c.cliApp.ErrWriter = &c.errBuffer
 		err := c.cliApp.Run(c.args)
 		if c.expectedErrContains != "" {
 			require.ErrorContains(t, err, c.expectedErrContains)
-		} else {
-			require.NoError(t, err)
-			require.Equal(t, c.expectedConfig.clusterName, client.clusterName)
-			require.Equal(t, c.expectedConfig.proxyURL.Host, client.proxyURL.Host)
-			require.Equal(t, c.expectedConfig.proxyURL.Scheme, client.proxyURL.Scheme)
-			require.Equal(t, c.expectedConfig.resource, client.resource)
+			continue
 		}
 
-		client = &GenerateClient{}
+		require.NoError(t, err)
+		require.Equal(t, c.expectedConfig.clusterName, client.clusterName)
+		require.Equal(t, c.expectedConfig.proxyURL.Host, client.proxyURL.Host)
+		require.Equal(t, c.expectedConfig.proxyURL.Scheme, client.proxyURL.Scheme)
+		require.Equal(t, c.expectedConfig.resource, client.resource)
 	}
 }
 

--- a/cmd/kubectl-azad-proxy/actions/generate_test.go
+++ b/cmd/kubectl-azad-proxy/actions/generate_test.go
@@ -204,6 +204,8 @@ func TestGenerate(t *testing.T) {
 			continue
 		}
 
+		require.NoError(t, err)
+
 		kubeCfg, err := k8sclientcmd.LoadFromFile(c.GenerateClient.kubeConfig)
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("%s://%s", c.GenerateClient.proxyURL.Scheme, c.GenerateClient.proxyURL.Host), kubeCfg.Clusters[c.GenerateClient.clusterName].Server)

--- a/cmd/kubectl-azad-proxy/actions/generate_test.go
+++ b/cmd/kubectl-azad-proxy/actions/generate_test.go
@@ -81,7 +81,7 @@ func TestNewGenerateClient(t *testing.T) {
 			args:   []string{"fake-binary", "test", "--cluster-name=test", "--proxy-url=https://fake", "--resource=https://fake"},
 			expectedConfig: &GenerateClient{
 				clusterName: "test",
-				proxyURL:    getURL("https://fake"),
+				proxyURL:    testGetURL(t, "https://fake"),
 				resource:    "https://fake",
 			},
 			expectedErrContains: "",
@@ -111,7 +111,7 @@ func TestNewGenerateClient(t *testing.T) {
 func TestMergeGenerateClient(t *testing.T) {
 	client := &GenerateClient{
 		clusterName:        "test",
-		proxyURL:           getURL("https://www.google.com"),
+		proxyURL:           testGetURL(t, "https://www.google.com"),
 		resource:           "https://fake",
 		kubeConfig:         "/tmp/kubeconfig",
 		tokenCacheDir:      "/tmp/tokencache",
@@ -126,7 +126,7 @@ func TestMergeGenerateClient(t *testing.T) {
 
 	client.Merge(GenerateClient{
 		clusterName:        "test2",
-		proxyURL:           getURL("https://www.example.com"),
+		proxyURL:           testGetURL(t, "https://www.example.com"),
 		resource:           "https://fake2",
 		kubeConfig:         "/tmp2/kubeconfig",
 		tokenCacheDir:      "/tmp2/tokencache",
@@ -151,11 +151,11 @@ func TestGenerate(t *testing.T) {
 
 	tokenCacheDir := tmpDir
 	kubeConfigFile := fmt.Sprintf("%s/kubeconfig", tmpDir)
-	defer deleteFile(t, kubeConfigFile)
+	defer testDeleteFile(t, kubeConfigFile)
 
 	client := &GenerateClient{
 		clusterName:        "test",
-		proxyURL:           getURL("https://www.google.com"),
+		proxyURL:           testGetURL(t, "https://www.google.com"),
 		resource:           "https://fake",
 		kubeConfig:         kubeConfigFile,
 		tokenCacheDir:      tokenCacheDir,
@@ -185,7 +185,7 @@ func TestGenerate(t *testing.T) {
 			GenerateClient: client,
 			GenerateClientFunc: func(oldClient *GenerateClient) *GenerateClient {
 				client := oldClient
-				client.proxyURL = getURL("https://localhost:12345")
+				client.proxyURL = testGetURL(t, "https://localhost:12345")
 				client.overwrite = true
 				return client
 			},
@@ -214,7 +214,11 @@ func TestGenerate(t *testing.T) {
 	}
 }
 
-func getURL(s string) url.URL {
-	res, _ := url.Parse(s)
+func testGetURL(t *testing.T, s string) url.URL {
+	t.Helper()
+
+	res, err := url.Parse(s)
+	require.NoError(t, err)
+
 	return *res
 }

--- a/cmd/kubectl-azad-proxy/actions/login_test.go
+++ b/cmd/kubectl-azad-proxy/actions/login_test.go
@@ -100,18 +100,18 @@ func TestNewLoginClient(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
-	tenantID := getEnvOrSkip(t, "TENANT_ID")
-	clientID := getEnvOrSkip(t, "TEST_USER_SP_CLIENT_ID")
-	clientSecret := getEnvOrSkip(t, "TEST_USER_SP_CLIENT_SECRET")
-	resource := getEnvOrSkip(t, "TEST_USER_SP_RESOURCE")
+	tenantID := testGetEnvOrSkip(t, "TENANT_ID")
+	clientID := testGetEnvOrSkip(t, "TEST_USER_SP_CLIENT_ID")
+	clientSecret := testGetEnvOrSkip(t, "TEST_USER_SP_CLIENT_SECRET")
+	resource := testGetEnvOrSkip(t, "TEST_USER_SP_RESOURCE")
 
-	restoreTenantID := tempChangeEnv("AZURE_TENANT_ID", tenantID)
+	restoreTenantID := testTempChangeEnv(t, "AZURE_TENANT_ID", tenantID)
 	defer restoreTenantID()
 
-	restoreClientID := tempChangeEnv("AZURE_CLIENT_ID", clientID)
+	restoreClientID := testTempChangeEnv(t, "AZURE_CLIENT_ID", clientID)
 	defer restoreClientID()
 
-	restoreClientSecret := tempChangeEnv("AZURE_CLIENT_SECRET", clientSecret)
+	restoreClientSecret := testTempChangeEnv(t, "AZURE_CLIENT_SECRET", clientSecret)
 	defer restoreClientSecret()
 
 	curDir, err := os.Getwd()
@@ -119,7 +119,7 @@ func TestLogin(t *testing.T) {
 		t.Errorf("Expected err to be nil: %q", err)
 	}
 	tokenCacheFile := fmt.Sprintf("%s/../../../tmp/%s", curDir, tokenCacheFileName)
-	defer deleteFile(t, tokenCacheFile)
+	defer testDeleteFile(t, tokenCacheFile)
 
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	client := &LoginClient{

--- a/cmd/kubectl-azad-proxy/actions/login_test.go
+++ b/cmd/kubectl-azad-proxy/actions/login_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -84,32 +83,19 @@ func TestNewLoginClient(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		client = &LoginClient{}
 		c.cliApp.Writer = &c.outBuffer
 		c.cliApp.ErrWriter = &c.errBuffer
 		err := c.cliApp.Run(c.args)
-		if err != nil && c.expectedErrContains == "" {
-			t.Errorf("Expected err to be nil: %q", err)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
 		}
 
-		if err == nil && c.expectedErrContains != "" {
-			t.Errorf("Expected err to contain '%s' but was nil", c.expectedErrContains)
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.expectedConfig.clusterName, client.clusterName)
+		require.Equal(t, c.expectedConfig.resource, client.resource)
 
-		if err != nil && c.expectedErrContains != "" {
-			if !strings.Contains(err.Error(), c.expectedErrContains) {
-				t.Errorf("Expected err to contain '%s' but was: %q", c.expectedErrContains, err)
-			}
-		}
-
-		if c.expectedErrContains == "" {
-			if client.clusterName != c.expectedConfig.clusterName {
-				t.Errorf("Expected client.clusterName to be '%s' but was: %s", c.expectedConfig.clusterName, client.clusterName)
-			}
-			if client.resource != c.expectedConfig.resource {
-				t.Errorf("Expected client.resource to be '%s' but was: %s", c.expectedConfig.resource, client.resource)
-			}
-		}
-		client = &LoginClient{}
 	}
 }
 
@@ -178,35 +164,18 @@ func TestLogin(t *testing.T) {
 
 	for _, c := range cases {
 		rawRes, err := c.LoginClient.Login(ctx)
-		if err != nil && c.expectedErrContains == "" {
-			t.Errorf("Expected err to be nil: %q", err)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
 		}
 
-		if err == nil && c.expectedErrContains != "" {
-			t.Errorf("Expected err to contain '%s' but was nil", c.expectedErrContains)
-		}
+		require.NoError(t, err)
 
-		if err != nil && c.expectedErrContains != "" {
-			if !strings.Contains(err.Error(), c.expectedErrContains) {
-				t.Errorf("Expected err to contain '%s' but was: %q", c.expectedErrContains, err)
-			}
-		}
-
-		if c.expectedErrContains == "" {
-			tokenRes := &k8sclientauth.ExecCredential{}
-			err = json.Unmarshal([]byte(rawRes), &tokenRes)
-			if err != nil && c.expectedErrContains == "" {
-				t.Errorf("Expected err to be nil: %q", err)
-			}
-
-			if tokenRes.APIVersion != "client.authentication.k8s.io/v1beta1" {
-				t.Errorf("Expected tokenRes.APIVersion to be '%s' but was: %s", "client.authentication.k8s.io/v1beta1", tokenRes.APIVersion)
-			}
-
-			if tokenRes.Kind != "ExecCredential" {
-				t.Errorf("Expected tokenRes.Kind to be '%s' but was: %s", "ExecCredential", tokenRes.Kind)
-			}
-		}
+		tokenRes := &k8sclientauth.ExecCredential{}
+		err = json.Unmarshal([]byte(rawRes), &tokenRes)
+		require.NoError(t, err)
+		require.Equal(t, "client.authentication.k8s.io/v1beta1", tokenRes.APIVersion)
+		require.Equal(t, "ExecCredential", tokenRes.Kind)
 	}
 }
 

--- a/cmd/kubectl-azad-proxy/actions/menu_test.go
+++ b/cmd/kubectl-azad-proxy/actions/menu_test.go
@@ -44,9 +44,7 @@ func TestNewMenuClient(t *testing.T) {
 	app.Writer = &bytes.Buffer{}
 	app.ErrWriter = &bytes.Buffer{}
 	err = app.Run([]string{"fake-binary", "test"})
-	if err != nil {
-		t.Errorf("Expected err to be nil: %q", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestMenu(t *testing.T) {
@@ -122,14 +120,14 @@ func TestMenu(t *testing.T) {
 		},
 	}
 
-	for idx, c := range cases {
+	for _, c := range cases {
 		err := c.menuClient.Menu(ctx)
-		if err != nil && !c.expectedErr {
-			t.Errorf("Expected err (%d) to be nil: %q", idx, err)
+		if c.expectedErr {
+			require.Error(t, err)
+			continue
 		}
-		if err == nil && c.expectedErr {
-			t.Errorf("Expected err (%d) not to be nil", idx)
-		}
+
+		require.NoError(t, err)
 	}
 }
 
@@ -237,9 +235,7 @@ func TestMergeFlags(t *testing.T) {
 
 	for _, c := range cases {
 		flags := mergeFlags(c.a, c.b)
-		if len(flags) != c.expectedLength {
-			t.Errorf("Expected flags length to be '%d' but was: %d", c.expectedLength, len(flags))
-		}
+		require.Len(t, flags, c.expectedLength)
 	}
 }
 
@@ -303,9 +299,7 @@ func TestUnrequireFlags(t *testing.T) {
 	for _, c := range cases {
 		flags := unrequireFlags(c.a)
 		for _, flag := range flags {
-			if flag.(*cli.StringFlag).Required {
-				t.Errorf("Expected flag to be 'false' but was 'true'")
-			}
+			require.False(t, flag.(*cli.StringFlag).Required)
 		}
 	}
 }

--- a/cmd/kubectl-azad-proxy/customerrors/customerrors_test.go
+++ b/cmd/kubectl-azad-proxy/customerrors/customerrors_test.go
@@ -2,8 +2,9 @@ package customerrors
 
 import (
 	"errors"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestError(t *testing.T) {
@@ -51,21 +52,14 @@ func TestError(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if strings.Contains(c.errorContains, c.customError.Error()) {
-			t.Errorf("Expected customError to contain %q but was: %q", c.errorContains, c.customError.Error())
-		}
+		require.ErrorContains(t, c.customError, c.errorContains)
 	}
 }
 
 func TestNew(t *testing.T) {
 	ce := New(ErrorTypeUnknown, errors.New("Unknown"))
-	if ce.ErrorType != ErrorTypeUnknown {
-		t.Errorf("Expected ErrorType to be ErrorTypeUnknown: %q", ce.ErrorType)
-	}
-
-	if ce.ErrorMessage != "Unknown" {
-		t.Errorf("Expected ErrorMessage to be 'Unknown': %q", ce.ErrorMessage)
-	}
+	require.Equal(t, ErrorTypeUnknown, ce.ErrorType)
+	require.Equal(t, "Unknown", ce.ErrorMessage)
 }
 
 func TestTo(t *testing.T) {
@@ -75,21 +69,11 @@ func TestTo(t *testing.T) {
 	}
 
 	ce := To(a)
-	if ce.ErrorType != ErrorTypeUnknown {
-		t.Errorf("Expected ErrorType to be ErrorTypeUnknown: %q", ce.ErrorType)
-	}
-
-	if ce.ErrorMessage != "Unknown" {
-		t.Errorf("Expected ErrorMessage to be 'Unknown': %q", ce.ErrorMessage)
-	}
+	require.Equal(t, ErrorTypeUnknown, ce.ErrorType)
+	require.Equal(t, "Unknown", ce.ErrorMessage)
 
 	b := errors.New("Fake")
 	ce = To(b)
-	if ce.ErrorType != ErrorTypeUnknown {
-		t.Errorf("Expected ErrorType to be ErrorTypeUnknown: %q", ce.ErrorType)
-	}
-
-	if ce.ErrorMessage != "Non-default error" {
-		t.Errorf("Expected ErrorMessage to be 'Non-default error': %q", ce.ErrorMessage)
-	}
+	require.Equal(t, ErrorTypeUnknown, ce.ErrorType)
+	require.Equal(t, "Non-default error", ce.ErrorMessage)
 }

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func TestNewAzureClient(t *testing.T) {
-	clientID := getEnvOrSkip(t, "CLIENT_ID")
-	clientSecret := getEnvOrSkip(t, "CLIENT_SECRET")
-	tenantID := getEnvOrSkip(t, "TENANT_ID")
+	clientID := testGetEnvOrSkip(t, "CLIENT_ID")
+	clientSecret := testGetEnvOrSkip(t, "CLIENT_SECRET")
+	tenantID := testGetEnvOrSkip(t, "TENANT_ID")
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 
 	memCache, err := cache.NewCache(ctx, models.MemoryCacheEngine, config.Config{})
@@ -75,9 +75,9 @@ func TestNewAzureClient(t *testing.T) {
 }
 
 func TestValid(t *testing.T) {
-	clientID := getEnvOrSkip(t, "CLIENT_ID")
-	clientSecret := getEnvOrSkip(t, "CLIENT_SECRET")
-	tenantID := getEnvOrSkip(t, "TENANT_ID")
+	clientID := testGetEnvOrSkip(t, "CLIENT_ID")
+	clientSecret := testGetEnvOrSkip(t, "CLIENT_SECRET")
+	tenantID := testGetEnvOrSkip(t, "TENANT_ID")
 	graphFilter := ""
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 
@@ -104,11 +104,11 @@ func TestValid(t *testing.T) {
 }
 
 func TestGetUserGroups(t *testing.T) {
-	clientID := getEnvOrSkip(t, "CLIENT_ID")
-	clientSecret := getEnvOrSkip(t, "CLIENT_SECRET")
-	tenantID := getEnvOrSkip(t, "TENANT_ID")
-	userObjectID := getEnvOrSkip(t, "TEST_USER_OBJECT_ID")
-	spObjectID := getEnvOrSkip(t, "TEST_USER_SP_OBJECT_ID")
+	clientID := testGetEnvOrSkip(t, "CLIENT_ID")
+	clientSecret := testGetEnvOrSkip(t, "CLIENT_SECRET")
+	tenantID := testGetEnvOrSkip(t, "TENANT_ID")
+	userObjectID := testGetEnvOrSkip(t, "TEST_USER_OBJECT_ID")
+	spObjectID := testGetEnvOrSkip(t, "TEST_USER_SP_OBJECT_ID")
 	graphFilter := ""
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 
@@ -160,9 +160,9 @@ func TestGetUserGroups(t *testing.T) {
 }
 
 func TestStartSyncGroups(t *testing.T) {
-	clientID := getEnvOrSkip(t, "CLIENT_ID")
-	clientSecret := getEnvOrSkip(t, "CLIENT_SECRET")
-	tenantID := getEnvOrSkip(t, "TENANT_ID")
+	clientID := testGetEnvOrSkip(t, "CLIENT_ID")
+	clientSecret := testGetEnvOrSkip(t, "CLIENT_SECRET")
+	tenantID := testGetEnvOrSkip(t, "TENANT_ID")
 	graphFilter := ""
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 
@@ -182,7 +182,9 @@ func TestStartSyncGroups(t *testing.T) {
 	defer stopGroupSync()
 }
 
-func getEnvOrSkip(t *testing.T, envVar string) string {
+func testGetEnvOrSkip(t *testing.T, envVar string) string {
+	t.Helper()
+
 	v := os.Getenv(envVar)
 	if v == "" {
 		t.Skipf("%s environment variable is empty, skipping.", envVar)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2,12 +2,12 @@ package cache
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 	"github.com/xenitab/azad-kube-proxy/pkg/config"
 	"github.com/xenitab/azad-kube-proxy/pkg/models"
 )
@@ -15,57 +15,51 @@ import (
 func TestNewCache(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	redisServer, err := miniredis.Run()
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 	defer redisServer.Close()
 
 	redisURL := fmt.Sprintf("redis://%s/0", redisServer.Addr())
 
 	cases := []struct {
-		cacheEngine models.CacheEngine
-		config      config.Config
-		expectedErr error
+		cacheEngine         models.CacheEngine
+		config              config.Config
+		expectedErrContains string
 	}{
 		{
-			cacheEngine: models.MemoryCacheEngine,
-			config:      config.Config{},
-			expectedErr: nil,
+			cacheEngine:         models.MemoryCacheEngine,
+			config:              config.Config{},
+			expectedErrContains: "",
 		},
 		{
 			cacheEngine: models.RedisCacheEngine,
 			config: config.Config{
 				RedisURI: redisURL,
 			},
-			expectedErr: nil,
+			expectedErrContains: "",
 		},
 		{
-			cacheEngine: models.RedisCacheEngine,
-			config:      config.Config{},
-			expectedErr: errors.New("redis: invalid URL scheme: "),
+			cacheEngine:         models.RedisCacheEngine,
+			config:              config.Config{},
+			expectedErrContains: "redis: invalid URL scheme: ",
 		},
 		{
-			cacheEngine: "",
-			config:      config.Config{},
-			expectedErr: errors.New("Unknown cache engine: "),
+			cacheEngine:         "",
+			config:              config.Config{},
+			expectedErrContains: "Unknown cache engine: ",
 		},
 		{
-			cacheEngine: "DUMMY",
-			config:      config.Config{},
-			expectedErr: errors.New("Unknown cache engine: DUMMY"),
+			cacheEngine:         "DUMMY",
+			config:              config.Config{},
+			expectedErrContains: "Unknown cache engine: DUMMY",
 		},
 	}
 
 	for _, c := range cases {
 		_, err := NewCache(ctx, c.cacheEngine, c.config)
-		if err != nil && c.expectedErr == nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
 		}
-
-		if c.expectedErr != nil {
-			if err.Error() != c.expectedErr.Error() {
-				t.Errorf("Expected err to be %q but it was %q", c.expectedErr, err)
-			}
-		}
+		require.NoError(t, err)
 	}
 }

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -21,7 +21,7 @@ func TestMemoryGetUser(t *testing.T) {
 	cache, err := NewMemoryCache(5*time.Minute, 10*time.Minute)
 	require.NoError(t, err)
 
-	cases, _ := getMemoryCases()
+	cases, _ := testGetMemoryCases(t)
 
 	for _, c := range cases {
 		cache.CacheClient.Set(c.Key, c.User, 0)
@@ -40,7 +40,7 @@ func TestMemorySetUser(t *testing.T) {
 	cache, err := NewMemoryCache(5*time.Minute, 10*time.Minute)
 	require.NoError(t, err)
 
-	cases, _ := getMemoryCases()
+	cases, _ := testGetMemoryCases(t)
 
 	for _, c := range cases {
 		err := cache.SetUser(ctx, c.Key, c.User)
@@ -59,7 +59,7 @@ func TestMemoryGetGroup(t *testing.T) {
 		t.Errorf("Expected err to be nil but it was %q", err)
 	}
 
-	_, cases := getMemoryCases()
+	_, cases := testGetMemoryCases(t)
 
 	for _, c := range cases {
 		cache.CacheClient.Set(c.Key, c.Group, 0)
@@ -81,7 +81,7 @@ func TestMemorySetGroup(t *testing.T) {
 		t.Errorf("Expected err to be nil but it was %q", err)
 	}
 
-	_, cases := getMemoryCases()
+	_, cases := testGetMemoryCases(t)
 
 	for _, c := range cases {
 		err := cache.SetGroup(ctx, c.Key, c.Group)
@@ -101,18 +101,20 @@ func TestMemorySetGroup(t *testing.T) {
 	}
 }
 
-type memoryUserCase struct {
+type testMemoryUserCase struct {
 	User models.User
 	Key  string
 }
 
-type memoryGroupCase struct {
+type testMemoryGroupCase struct {
 	Group models.Group
 	Key   string
 }
 
-func getMemoryCases() ([]memoryUserCase, []memoryGroupCase) {
-	userCases := []memoryUserCase{
+func testGetMemoryCases(t *testing.T) ([]testMemoryUserCase, []testMemoryGroupCase) {
+	t.Helper()
+
+	userCases := []testMemoryUserCase{
 		{
 			User: models.User{
 				Username: "user1",
@@ -160,7 +162,7 @@ func getMemoryCases() ([]memoryUserCase, []memoryGroupCase) {
 		},
 	}
 
-	groupCases := []memoryGroupCase{
+	groupCases := []testMemoryGroupCase{
 		{
 			Group: models.Group{Name: "group1"},
 			Key:   "00000000-0000-0000-0000-000000000000",

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -7,70 +7,48 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"github.com/xenitab/azad-kube-proxy/pkg/models"
 )
 
 func TestNewMemoryCache(t *testing.T) {
 	_, err := NewMemoryCache(5*time.Minute, 10*time.Minute)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestMemoryGetUser(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	cache, err := NewMemoryCache(5*time.Minute, 10*time.Minute)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	cases, _ := getMemoryCases()
 
 	for _, c := range cases {
 		cache.CacheClient.Set(c.Key, c.User, 0)
 		cacheRes, found, err := cache.GetUser(ctx, c.Key)
-		if !cmp.Equal(c.User, cacheRes) {
-			t.Errorf("Expected response was not returned.\nExpected: %s\nActual:   %s", c.User, cacheRes)
-		}
-		if err != nil {
-			t.Errorf("Did not expect error: %q", err)
-		}
-		if !found {
-			t.Errorf("Expected cached user to be found")
-		}
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, c.User, cacheRes)
 	}
 
 	_, found, _ := cache.GetUser(ctx, "does-not-exist")
-	if found {
-		t.Errorf("Expected cached user not to be found")
-	}
+	require.False(t, found)
 }
 
 func TestMemorySetUser(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	cache, err := NewMemoryCache(5*time.Minute, 10*time.Minute)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	cases, _ := getMemoryCases()
 
 	for _, c := range cases {
 		err := cache.SetUser(ctx, c.Key, c.User)
-		if err != nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
+		require.NoError(t, err)
 
 		cacheRes, found := cache.CacheClient.Get(c.Key)
-		if !cmp.Equal(c.User, cacheRes.(models.User)) {
-			t.Errorf("Expected response was not returned.\nExpected: %s\nActual:   %s", c.User, cacheRes.(models.User))
-		}
-		if err != nil {
-			t.Errorf("Did not expect error: %q", err)
-		}
-		if !found {
-			t.Errorf("Expected cached user to be found")
-		}
+		require.True(t, found)
+		require.Equal(t, c.User, cacheRes.(models.User))
 	}
 }
 
@@ -86,21 +64,14 @@ func TestMemoryGetGroup(t *testing.T) {
 	for _, c := range cases {
 		cache.CacheClient.Set(c.Key, c.Group, 0)
 		cacheRes, found, err := cache.GetGroup(ctx, c.Key)
-		if !cmp.Equal(c.Group, cacheRes) {
-			t.Errorf("Expected response was not returned.\nExpected: %s\nActual:   %s", c.Group, cacheRes)
-		}
-		if err != nil {
-			t.Errorf("Did not expect error: %q", err)
-		}
-		if !found {
-			t.Errorf("Expected cached user to be found")
-		}
+
+		require.NoError(t, err)
+		require.Equal(t, c.Group, cacheRes)
+		require.True(t, found)
 	}
 
 	_, found, _ := cache.GetGroup(ctx, "does-not-exist")
-	if found {
-		t.Errorf("Expected cached group not to be found")
-	}
+	require.False(t, found)
 }
 
 func TestMemorySetGroup(t *testing.T) {

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-logr/logr"
 	"github.com/go-redis/redis/v8"
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"github.com/xenitab/azad-kube-proxy/pkg/models"
 )
 
@@ -38,286 +37,175 @@ func (i fakeErrorGroup) MarshalBinary() ([]byte, error) {
 func TestNewRedisCache(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	redisServer, err := miniredis.Run()
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 	defer redisServer.Close()
 
 	redisURL := fmt.Sprintf("redis://%s/0", redisServer.Addr())
 
 	_, err = NewRedisCache(ctx, redisURL, redisTimeout)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	_, err = NewRedisCache(ctx, "", redisTimeout)
-	if err.Error() != "redis: invalid URL scheme: " {
-		t.Errorf("Expected err to contain 'redis: invalid URL scheme: ' but was: %q", err)
-	}
+	require.ErrorContains(t, err, "redis: invalid URL scheme: ")
 
 	redisServer.Close()
 	_, err = NewRedisCache(ctx, redisURL, redisTimeout)
-	if !strings.Contains(err.Error(), "connect: connection refused") {
-		t.Errorf("Expected err to contain 'connect: connection refused' but was: %q", err)
-	}
+	require.ErrorContains(t, err, "connect: connection refused")
 }
 
 func TestRedisGetUser(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	redisServer, err := miniredis.Run()
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	redisURL := fmt.Sprintf("redis://%s/0", redisServer.Addr())
 	miniredisClient, err := getMiniredisClient(redisURL)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 	defer redisServer.Close()
 
 	cache, err := NewRedisCache(ctx, redisURL, redisTimeout)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	cases, _ := getRedisCases()
 
 	for _, c := range cases {
 		err := miniredisClient.SetNX(ctx, c.Key, c.User, redisTimeout).Err()
-		if err != nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
+		require.NoError(t, err)
 		cacheRes, found, err := cache.GetUser(ctx, c.Key)
-		if !cmp.Equal(c.User, cacheRes) {
-			t.Errorf("Expected response was not returned.\nExpected: %s\nActual:   %s", c.User, cacheRes)
-		}
-		if err != nil {
-			t.Errorf("Did not expect error: %q", err)
-		}
-		if !found {
-			t.Errorf("Expected cached user to be found")
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.User, cacheRes)
+		require.True(t, found)
 	}
 
 	// Not found
 	_, found, _ := cache.GetUser(ctx, "does-not-exist")
-	if found {
-		t.Errorf("Expected cached user not to be found")
-	}
+	require.False(t, found)
 
 	// Unmarshal error
 	fakeErrorUser := fakeErrorUser{
 		Username: false,
 	}
 	err = miniredisClient.SetNX(ctx, "fake-error-user", fakeErrorUser, redisTimeout).Err()
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	_, _, err = cache.GetUser(ctx, "fake-error-user")
-	if !strings.Contains(err.Error(), "json: cannot unmarshal") {
-		t.Errorf("Expected error to contain 'json: cannot unmarshal' but it was: %q", err)
-	}
+	require.ErrorContains(t, err, "json: cannot unmarshal")
 
 	// Connection error
 	redisServer.Close()
 	_, _, err = cache.GetUser(ctx, "no-redis-server")
-	if !strings.Contains(err.Error(), "connect: connection refused") {
-		t.Errorf("Expected error to contain 'connect: connection refused' but it was: %q", err)
-	}
+	require.ErrorContains(t, err, "connect: connection refused")
 }
 
 func TestRedisSetUser(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	redisServer, err := miniredis.Run()
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 	defer redisServer.Close()
 
 	redisURL := fmt.Sprintf("redis://%s/0", redisServer.Addr())
 	miniredisClient, err := getMiniredisClient(redisURL)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	cache, err := NewRedisCache(ctx, redisURL, redisTimeout)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	cases, _ := getRedisCases()
 
 	for _, c := range cases {
 		err := cache.SetUser(ctx, c.Key, c.User)
-		if err != nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
+		require.NoError(t, err)
 
 		res := miniredisClient.Get(ctx, c.Key)
-		found := true
-		err = res.Err()
-		if err != nil {
-			if err == redis.Nil {
-				found = false
-			} else {
-				t.Errorf("Expected err to be nil but it was %q", err)
-			}
-		}
+		require.NoError(t, res.Err())
 
 		var u models.User
-
 		err = res.Scan(&u)
-		if err != nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
-
-		if !cmp.Equal(c.User, u) {
-			t.Errorf("Expected response was not returned.\nExpected: %s\nActual:   %s", c.User, u)
-		}
-		if err != nil {
-			t.Errorf("Did not expect error: %q", err)
-		}
-		if !found {
-			t.Errorf("Expected cached user to be found")
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.User, u)
 	}
 
 	redisServer.Close()
 	err = cache.SetUser(ctx, "no-redis-server", models.User{})
-	if !strings.Contains(err.Error(), "connect: connection refused") {
-		t.Errorf("Expected error to contain 'connect: connection refused' but it was: %q", err)
-	}
+	require.ErrorContains(t, err, "connect: connection refused")
 }
 
 func TestRedisGetGroup(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	redisServer, err := miniredis.Run()
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 	defer redisServer.Close()
 
 	redisURL := fmt.Sprintf("redis://%s/0", redisServer.Addr())
 	miniredisClient, err := getMiniredisClient(redisURL)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	cache, err := NewRedisCache(ctx, redisURL, redisTimeout)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	_, cases := getRedisCases()
 
 	for _, c := range cases {
 		err := miniredisClient.SetNX(ctx, c.Key, c.Group, redisTimeout).Err()
-		if err != nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
+		require.NoError(t, err)
 		cacheRes, found, err := cache.GetGroup(ctx, c.Key)
-		if !cmp.Equal(c.Group, cacheRes) {
-			t.Errorf("Expected response was not returned.\nExpected: %s\nActual:   %s", c.Group, cacheRes)
-		}
-		if err != nil {
-			t.Errorf("Did not expect error: %q", err)
-		}
-		if !found {
-			t.Errorf("Expected cached group to be found")
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.Group, cacheRes)
+		require.True(t, found)
 	}
 
 	// Not found
 	_, found, _ := cache.GetGroup(ctx, "does-not-exist")
-	if found {
-		t.Errorf("Expected cached group not to be found")
-	}
+	require.False(t, found)
 
 	// Unmarshal error
 	fakeErrorGroup := fakeErrorGroup{
 		Name: false,
 	}
 	err = miniredisClient.SetNX(ctx, "fake-error-group", fakeErrorGroup, redisTimeout).Err()
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	_, _, err = cache.GetGroup(ctx, "fake-error-group")
-	if !strings.Contains(err.Error(), "json: cannot unmarshal") {
-		t.Errorf("Expected error to contain 'json: cannot unmarshal' but it was: %q", err)
-	}
+	require.ErrorContains(t, err, "json: cannot unmarshal")
 
 	// Connection error
 	redisServer.Close()
 	_, _, err = cache.GetGroup(ctx, "no-redis-server")
-	if !strings.Contains(err.Error(), "connect: connection refused") {
-		t.Errorf("Expected error to contain 'connect: connection refused' but it was: %q", err)
-	}
+	require.ErrorContains(t, err, "connect: connection refused")
 }
 
 func TestRedisSetGroup(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	redisServer, err := miniredis.Run()
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 	defer redisServer.Close()
 
 	redisURL := fmt.Sprintf("redis://%s/0", redisServer.Addr())
 	miniredisClient, err := getMiniredisClient(redisURL)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	cache, err := NewRedisCache(ctx, redisURL, redisTimeout)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	_, cases := getRedisCases()
 
 	for _, c := range cases {
 		err := cache.SetGroup(ctx, c.Key, c.Group)
-		if err != nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
+		require.NoError(t, err)
 
 		res := miniredisClient.Get(ctx, c.Key)
-		found := true
-		err = res.Err()
-		if err != nil {
-			if err == redis.Nil {
-				found = false
-			} else {
-				t.Errorf("Expected err to be nil but it was %q", err)
-			}
-		}
+		require.NoError(t, res.Err())
 
 		var g models.Group
 
 		err = res.Scan(&g)
-		if err != nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
-
-		if !cmp.Equal(c.Group, g) {
-			t.Errorf("Expected response was not returned.\nExpected: %s\nActual:   %s", c.Group, g)
-		}
-		if err != nil {
-			t.Errorf("Did not expect error: %q", err)
-		}
-		if !found {
-			t.Errorf("Expected cached group to be found")
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.Group, g)
 	}
 
 	redisServer.Close()
 	err = cache.SetGroup(ctx, "no-redis-server", models.Group{})
-	if !strings.Contains(err.Error(), "connect: connection refused") {
-		t.Errorf("Expected error to contain 'connect: connection refused' but it was: %q", err)
-	}
+	require.ErrorContains(t, err, "connect: connection refused")
 }
 
 func getMiniredisClient(redisURL string) (*redis.Client, error) {

--- a/pkg/cors/cors_test.go
+++ b/pkg/cors/cors_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
 	"github.com/xenitab/azad-kube-proxy/pkg/config"
 )
 
@@ -17,9 +18,7 @@ func TestMiddleware(t *testing.T) {
 	}))
 	defer fakeBackend.Close()
 	fakeBackendURL, err := url.Parse(fakeBackend.URL)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	cases := []struct {
 		config          config.Config
@@ -210,9 +209,7 @@ func TestMiddleware(t *testing.T) {
 		client := NewCORSClient(c.config)
 
 		req, err := http.NewRequest(c.reqMethod, "/", nil)
-		if err != nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
+		require.NoError(t, err)
 		req.Host = c.reqHost
 		req.Header.Add("Origin", c.reqOrigin)
 		for k, v := range c.reqHeaders {
@@ -227,16 +224,8 @@ func TestMiddleware(t *testing.T) {
 		router.Use(client.Middleware)
 		router.ServeHTTP(rr, req)
 
-		if rr.Result().Header.Get("Access-Control-Allow-Origin") != c.expectedOrigin {
-			t.Errorf("unexpected Access-Control-Allow-Origin header: got %v want %v", rr.Result().Header.Get("Access-Control-Allow-Origin"), c.expectedOrigin)
-		}
-
-		if rr.Result().Header.Get("Access-Control-Allow-Headers") != c.expectedHeaders {
-			t.Errorf("unexpected Access-Control-Allow-Headers header: got %v want %v", rr.Result().Header.Get("Access-Control-Allow-Headers"), c.expectedHeaders)
-		}
-
-		if rr.Result().Header.Get("Access-Control-Allow-Methods") != c.expectedMethods {
-			t.Errorf("unexpected Access-Control-Allow-Methods header: got %v want %v", rr.Result().Header.Get("Access-Control-Allow-Methods"), c.expectedMethods)
-		}
+		require.Equal(t, c.expectedOrigin, rr.Result().Header.Get("Access-Control-Allow-Origin"))
+		require.Equal(t, c.expectedHeaders, rr.Result().Header.Get("Access-Control-Allow-Headers"))
+		require.Equal(t, c.expectedMethods, rr.Result().Header.Get("Access-Control-Allow-Methods"))
 	}
 }

--- a/pkg/handlers/oidc_test.go
+++ b/pkg/handlers/oidc_test.go
@@ -38,5 +38,6 @@ func TestNewAzureADClaimsValidationFn(t *testing.T) {
 
 func testToPtr[P any](t *testing.T, v P) *P {
 	t.Helper()
+
 	return &v
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -3,10 +3,10 @@ package health
 import (
 	"context"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 	"github.com/xenitab/azad-kube-proxy/pkg/config"
 	k8sapiauthorization "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,19 +47,12 @@ func TestNewHealthClient(t *testing.T) {
 	for _, c := range cases {
 		validator := &fakeValidator{}
 		_, err := NewHealthClient(ctx, c.config, validator)
-		if err != nil && c.expectedErrContains == "" {
-			t.Errorf("Expected err to be nil: %q", err)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
 		}
 
-		if err == nil && c.expectedErrContains != "" {
-			t.Errorf("Expected err to contain '%s' but was nil", c.expectedErrContains)
-		}
-
-		if err != nil && c.expectedErrContains != "" {
-			if !strings.Contains(err.Error(), c.expectedErrContains) {
-				t.Errorf("Expected err to contain '%s' but was: %q", c.expectedErrContains, err)
-			}
-		}
+		require.NoError(t, err)
 	}
 }
 
@@ -111,23 +104,13 @@ func TestReady(t *testing.T) {
 		client := c.clientFunc(fakeClient)
 
 		ready, err := client.Ready(ctx)
-		if err != nil && c.expectedErrContains == "" {
-			t.Errorf("Expected err to be nil: %q", err)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
 		}
 
-		if err == nil && c.expectedErrContains != "" {
-			t.Errorf("Expected err to contain '%s' but was nil", c.expectedErrContains)
-		}
-
-		if err != nil && c.expectedErrContains != "" {
-			if !strings.Contains(err.Error(), c.expectedErrContains) {
-				t.Errorf("Expected err to contain '%s' but was: %q", c.expectedErrContains, err)
-			}
-		}
-
-		if c.expectedReady != ready {
-			t.Errorf("Expected ready to be '%t' but was: %t", c.expectedReady, ready)
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.expectedReady, ready)
 	}
 }
 
@@ -144,18 +127,11 @@ func TestLive(t *testing.T) {
 		},
 	}
 	client, err := NewHealthClient(ctx, fakeConfig, validator)
-	if err != nil {
-		t.Errorf("Expected err to be nil: %q", err)
-	}
+	require.NoError(t, err)
 
 	live, err := client.Live(ctx)
-	if err != nil {
-		t.Errorf("Expected err to be nil: %q", err)
-	}
-
-	if !live {
-		t.Errorf("Expected live to be 'true': %T", live)
-	}
+	require.NoError(t, err)
+	require.True(t, live)
 }
 
 type fakeValidator struct{}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -45,7 +45,7 @@ func TestNewHealthClient(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		validator := &fakeValidator{}
+		validator := &testFakeValidator{t}
 		_, err := NewHealthClient(ctx, c.config, validator)
 		if c.expectedErrContains != "" {
 			require.ErrorContains(t, err, c.expectedErrContains)
@@ -117,7 +117,7 @@ func TestReady(t *testing.T) {
 func TestLive(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 
-	validator := &fakeValidator{}
+	validator := &testFakeValidator{t}
 	fakeConfig := config.Config{
 		KubernetesConfig: config.KubernetesConfig{
 			ValidateCertificate: false,
@@ -134,9 +134,13 @@ func TestLive(t *testing.T) {
 	require.True(t, live)
 }
 
-type fakeValidator struct{}
+type testFakeValidator struct {
+	t *testing.T
+}
 
 // Valid ...
-func (client *fakeValidator) Valid(ctx context.Context) bool {
+func (client *testFakeValidator) Valid(ctx context.Context) bool {
+	client.t.Helper()
+
 	return true
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -2,10 +2,10 @@ package metrics
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 	"github.com/xenitab/azad-kube-proxy/pkg/config"
 	"github.com/xenitab/azad-kube-proxy/pkg/models"
 )
@@ -36,18 +36,11 @@ func TestNewMetricsClient(t *testing.T) {
 
 	for _, c := range cases {
 		_, err := NewMetricsClient(ctx, c.config)
-		if err != nil && c.expectedErrContains == "" {
-			t.Errorf("Expected err to be nil: %q", err)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
 		}
 
-		if err == nil && c.expectedErrContains != "" {
-			t.Errorf("Expected err to contain '%s' but was nil", c.expectedErrContains)
-		}
-
-		if err != nil && c.expectedErrContains != "" {
-			if !strings.Contains(err.Error(), c.expectedErrContains) {
-				t.Errorf("Expected err to contain '%s' but was: %q", c.expectedErrContains, err)
-			}
-		}
+		require.NoError(t, err)
 	}
 }

--- a/pkg/metrics/none_test.go
+++ b/pkg/metrics/none_test.go
@@ -6,53 +6,35 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNoneMetricsHandler(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	req, err := http.NewRequest("GET", "/metrics", nil)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	client := newNoneClient(ctx)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	fakeBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("{\"fake\": true}"))
 	}))
 	defer fakeBackend.Close()
 	fakeBackendURL, err := url.Parse(fakeBackend.URL)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	proxy := httputil.NewSingleHostReverseProxy(fakeBackendURL)
 	rr := httptest.NewRecorder()
 	router := mux.NewRouter()
 	router.PathPrefix("/").Handler(proxy)
 	router, err = client.MetricsHandler(ctx, router)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 	router.ServeHTTP(rr, req)
-
-	// Check the status code is what we expect.
-	if rr.Code != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK)
-	}
-
-	// Check the response body is what we expect.
-	expectedStringContains := "{\"fake\": true}"
-	if !strings.Contains(rr.Body.String(), expectedStringContains) {
-		t.Errorf("handler returned unexpected body: got %v expected to contain %v",
-			rr.Body.String(), expectedStringContains)
-	}
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "{\"fake\": true}")
 }

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -4,42 +4,26 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPrometheusMetricsHandler(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	req, err := http.NewRequest("GET", "/metrics", nil)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	client := newPrometheusClient(ctx)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
 	router := mux.NewRouter()
 	router, err = client.MetricsHandler(ctx, router)
-	if err != nil {
-		t.Errorf("Expected err to be nil but it was %q", err)
-	}
+	require.NoError(t, err)
 	router.ServeHTTP(rr, req)
-
-	// Check the status code is what we expect.
-	if rr.Code != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK)
-	}
-
-	// Check the response body is what we expect.
-	expectedStringContains := "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles."
-	if !strings.Contains(rr.Body.String(), expectedStringContains) {
-		t.Errorf("handler returned unexpected body: got %v expected to contain %v",
-			rr.Body.String(), expectedStringContains)
-	}
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.")
 }

--- a/pkg/models/cache_test.go
+++ b/pkg/models/cache_test.go
@@ -1,53 +1,47 @@
 package models
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCacheEngine(t *testing.T) {
 	cases := []struct {
 		cacheEngineString   string
 		expectedCacheEngine CacheEngine
-		expectedErr         error
+		expectedErrContains string
 	}{
 		{
 			cacheEngineString:   "MEMORY",
 			expectedCacheEngine: MemoryCacheEngine,
-			expectedErr:         nil,
+			expectedErrContains: "",
 		},
 		{
 			cacheEngineString:   "REDIS",
 			expectedCacheEngine: RedisCacheEngine,
-			expectedErr:         nil,
+			expectedErrContains: "",
 		},
 		{
 			cacheEngineString:   "",
 			expectedCacheEngine: "",
-			expectedErr:         errors.New("Unknown cache engine type ''. Supported engines are: MEMORY or REDIS"),
+			expectedErrContains: "Unknown cache engine type ''. Supported engines are: MEMORY or REDIS",
 		},
 		{
 			cacheEngineString:   "DUMMY",
 			expectedCacheEngine: "",
-			expectedErr:         errors.New("Unknown cache engine type 'DUMMY'. Supported engines are: MEMORY or REDIS"),
+			expectedErrContains: "Unknown cache engine type 'DUMMY'. Supported engines are: MEMORY or REDIS",
 		},
 	}
 
 	for _, c := range cases {
 		resCacheEngine, err := GetCacheEngine(c.cacheEngineString)
-
-		if resCacheEngine != c.expectedCacheEngine && c.expectedErr == nil {
-			t.Errorf("Expected cacheEngine (%s) was not returned: %s", c.expectedCacheEngine, resCacheEngine)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
 		}
 
-		if err != nil && c.expectedErr == nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
-
-		if c.expectedErr != nil {
-			if err.Error() != c.expectedErr.Error() {
-				t.Errorf("Expected err to be %q but it was %q", c.expectedErr, err)
-			}
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.expectedCacheEngine, resCacheEngine)
 	}
 }

--- a/pkg/models/metrics_test.go
+++ b/pkg/models/metrics_test.go
@@ -1,53 +1,47 @@
 package models
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetMetrics(t *testing.T) {
 	cases := []struct {
-		metricsString   string
-		expectedMetrics Metrics
-		expectedErr     error
+		metricsString       string
+		expectedMetrics     Metrics
+		expectedErrContains string
 	}{
 		{
-			metricsString:   "NONE",
-			expectedMetrics: NoneMetrics,
-			expectedErr:     nil,
+			metricsString:       "NONE",
+			expectedMetrics:     NoneMetrics,
+			expectedErrContains: "",
 		},
 		{
-			metricsString:   "PROMETHEUS",
-			expectedMetrics: PrometheusMetrics,
-			expectedErr:     nil,
+			metricsString:       "PROMETHEUS",
+			expectedMetrics:     PrometheusMetrics,
+			expectedErrContains: "",
 		},
 		{
-			metricsString:   "",
-			expectedMetrics: "",
-			expectedErr:     errors.New("Unknown metrics ''. Supported engines are: NONE or PROMETHEUS"),
+			metricsString:       "",
+			expectedMetrics:     "",
+			expectedErrContains: "Unknown metrics ''. Supported engines are: NONE or PROMETHEUS",
 		},
 		{
-			metricsString:   "DUMMY",
-			expectedMetrics: "",
-			expectedErr:     errors.New("Unknown metrics 'DUMMY'. Supported engines are: NONE or PROMETHEUS"),
+			metricsString:       "DUMMY",
+			expectedMetrics:     "",
+			expectedErrContains: "Unknown metrics 'DUMMY'. Supported engines are: NONE or PROMETHEUS",
 		},
 	}
 
 	for _, c := range cases {
 		resMetrics, err := GetMetrics(c.metricsString)
-
-		if resMetrics != c.expectedMetrics && c.expectedErr == nil {
-			t.Errorf("Expected cacheEngine (%s) was not returned: %s", c.expectedMetrics, resMetrics)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
 		}
 
-		if err != nil && c.expectedErr == nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
-
-		if c.expectedErr != nil {
-			if err.Error() != c.expectedErr.Error() {
-				t.Errorf("Expected err to be %q but it was %q", c.expectedErr, err)
-			}
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.expectedMetrics, resMetrics)
 	}
 }

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -7,15 +7,15 @@ import (
 )
 
 func TestMarshalBinary(t *testing.T) {
-	userCases, groupCases := getUseCases()
+	testUserCases, testGroupCases := testGetUseCases(t)
 
-	for _, c := range userCases {
+	for _, c := range testUserCases {
 		response, err := c.MarshalBinary()
 		require.NoError(t, err)
 		require.Equal(t, c.expectedString, string(response))
 	}
 
-	for _, c := range groupCases {
+	for _, c := range testGroupCases {
 		response, err := c.MarshalBinary()
 		require.NoError(t, err)
 		require.Equal(t, c.expectedString, string(response))
@@ -23,16 +23,16 @@ func TestMarshalBinary(t *testing.T) {
 }
 
 func TestUnmarshalBinary(t *testing.T) {
-	userCases, groupCases := getUseCases()
+	testUserCases, testGroupCases := testGetUseCases(t)
 
-	for _, c := range userCases {
+	for _, c := range testUserCases {
 		user := User{}
 		err := user.UnmarshalBinary([]byte(c.expectedString))
 		require.NoError(t, err)
 		require.Equal(t, c.User, user)
 	}
 
-	for _, c := range groupCases {
+	for _, c := range testGroupCases {
 		group := Group{}
 		err := group.UnmarshalBinary([]byte(c.expectedString))
 		require.NoError(t, err)
@@ -40,18 +40,60 @@ func TestUnmarshalBinary(t *testing.T) {
 	}
 }
 
-type userCase struct {
+func TestGetGroupIdentifier(t *testing.T) {
+	cases := []struct {
+		groupIdentifierString   string
+		expectedGroupIdentifier GroupIdentifier
+		expectedErrContains     string
+	}{
+		{
+			groupIdentifierString:   "NAME",
+			expectedGroupIdentifier: NameGroupIdentifier,
+			expectedErrContains:     "",
+		},
+		{
+			groupIdentifierString:   "OBJECTID",
+			expectedGroupIdentifier: ObjectIDGroupIdentifier,
+			expectedErrContains:     "",
+		},
+		{
+			groupIdentifierString:   "",
+			expectedGroupIdentifier: "",
+			expectedErrContains:     "Unknown group identifier ''. Supported identifiers are: NAME or OBJECTID",
+		},
+		{
+			groupIdentifierString:   "DUMMY",
+			expectedGroupIdentifier: "",
+			expectedErrContains:     "Unknown group identifier 'DUMMY'. Supported identifiers are: NAME or OBJECTID",
+		},
+	}
+
+	for _, c := range cases {
+		resGroupIdentifier, err := GetGroupIdentifier(c.groupIdentifierString)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
+		}
+
+		require.NoError(t, err)
+		require.Equal(t, c.expectedGroupIdentifier, resGroupIdentifier)
+	}
+}
+
+type testUserCase struct {
 	User
 	expectedString string
 }
 
-type groupCase struct {
+type testGroupCase struct {
 	Group
 	expectedString string
 }
 
-func getUseCases() ([]userCase, []groupCase) {
-	userCases := []userCase{
+func testGetUseCases(t *testing.T) ([]testUserCase, []testGroupCase) {
+	t.Helper()
+
+	testUserCases := []testUserCase{
 		{
 			User: User{
 				Username: "username",
@@ -104,7 +146,7 @@ func getUseCases() ([]userCase, []groupCase) {
 		},
 	}
 
-	groupCases := []groupCase{
+	testGroupCases := []testGroupCase{
 		{
 			Group: Group{
 				Name:     "test1",
@@ -114,45 +156,5 @@ func getUseCases() ([]userCase, []groupCase) {
 		},
 	}
 
-	return userCases, groupCases
-}
-
-func TestGetGroupIdentifier(t *testing.T) {
-	cases := []struct {
-		groupIdentifierString   string
-		expectedGroupIdentifier GroupIdentifier
-		expectedErrContains     string
-	}{
-		{
-			groupIdentifierString:   "NAME",
-			expectedGroupIdentifier: NameGroupIdentifier,
-			expectedErrContains:     "",
-		},
-		{
-			groupIdentifierString:   "OBJECTID",
-			expectedGroupIdentifier: ObjectIDGroupIdentifier,
-			expectedErrContains:     "",
-		},
-		{
-			groupIdentifierString:   "",
-			expectedGroupIdentifier: "",
-			expectedErrContains:     "Unknown group identifier ''. Supported identifiers are: NAME or OBJECTID",
-		},
-		{
-			groupIdentifierString:   "DUMMY",
-			expectedGroupIdentifier: "",
-			expectedErrContains:     "Unknown group identifier 'DUMMY'. Supported identifiers are: NAME or OBJECTID",
-		},
-	}
-
-	for _, c := range cases {
-		resGroupIdentifier, err := GetGroupIdentifier(c.groupIdentifierString)
-		if c.expectedErrContains != "" {
-			require.ErrorContains(t, err, c.expectedErrContains)
-			continue
-		}
-
-		require.NoError(t, err)
-		require.Equal(t, c.expectedGroupIdentifier, resGroupIdentifier)
-	}
+	return testUserCases, testGroupCases
 }

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -1,10 +1,9 @@
 package models
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalBinary(t *testing.T) {
@@ -12,22 +11,14 @@ func TestMarshalBinary(t *testing.T) {
 
 	for _, c := range userCases {
 		response, err := c.MarshalBinary()
-		if c.expectedString != string(response) {
-			t.Errorf("User case: Expected response was not returned.\nExpected: %s\nActual:   %s", c.expectedString, response)
-		}
-		if err != nil {
-			t.Errorf("User case: Did not expect error: %q", err)
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.expectedString, string(response))
 	}
 
 	for _, c := range groupCases {
 		response, err := c.MarshalBinary()
-		if c.expectedString != string(response) {
-			t.Errorf("Group case: Expected response was not returned.\nExpected: %s\nActual:   %s", c.expectedString, response)
-		}
-		if err != nil {
-			t.Errorf("Group case: Did not expect error: %q", err)
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.expectedString, string(response))
 	}
 }
 
@@ -37,23 +28,15 @@ func TestUnmarshalBinary(t *testing.T) {
 	for _, c := range userCases {
 		user := User{}
 		err := user.UnmarshalBinary([]byte(c.expectedString))
-		if !cmp.Equal(c.User, user) {
-			t.Errorf("User case: Expected response was not returned.\nExpected: %s\nActual:   %s", c.User, user)
-		}
-		if err != nil {
-			t.Errorf("User case: Did not expect error: %q", err)
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.User, user)
 	}
 
 	for _, c := range groupCases {
 		group := Group{}
 		err := group.UnmarshalBinary([]byte(c.expectedString))
-		if !cmp.Equal(c.Group, group) {
-			t.Errorf("Group case: Expected response was not returned.\nExpected: %s\nActual:   %s", c.Group, group)
-		}
-		if err != nil {
-			t.Errorf("Group case: Did not expect error: %q", err)
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.Group, group)
 	}
 }
 
@@ -138,45 +121,38 @@ func TestGetGroupIdentifier(t *testing.T) {
 	cases := []struct {
 		groupIdentifierString   string
 		expectedGroupIdentifier GroupIdentifier
-		expectedErr             error
+		expectedErrContains     string
 	}{
 		{
 			groupIdentifierString:   "NAME",
 			expectedGroupIdentifier: NameGroupIdentifier,
-			expectedErr:             nil,
+			expectedErrContains:     "",
 		},
 		{
 			groupIdentifierString:   "OBJECTID",
 			expectedGroupIdentifier: ObjectIDGroupIdentifier,
-			expectedErr:             nil,
+			expectedErrContains:     "",
 		},
 		{
 			groupIdentifierString:   "",
 			expectedGroupIdentifier: "",
-			expectedErr:             errors.New("Unknown group identifier ''. Supported identifiers are: NAME or OBJECTID"),
+			expectedErrContains:     "Unknown group identifier ''. Supported identifiers are: NAME or OBJECTID",
 		},
 		{
 			groupIdentifierString:   "DUMMY",
 			expectedGroupIdentifier: "",
-			expectedErr:             errors.New("Unknown group identifier 'DUMMY'. Supported identifiers are: NAME or OBJECTID"),
+			expectedErrContains:     "Unknown group identifier 'DUMMY'. Supported identifiers are: NAME or OBJECTID",
 		},
 	}
 
 	for _, c := range cases {
 		resGroupIdentifier, err := GetGroupIdentifier(c.groupIdentifierString)
-
-		if resGroupIdentifier != c.expectedGroupIdentifier && c.expectedErr == nil {
-			t.Errorf("Expected group identifier (%s) was not returned: %s", c.expectedGroupIdentifier, resGroupIdentifier)
+		if c.expectedErrContains != "" {
+			require.ErrorContains(t, err, c.expectedErrContains)
+			continue
 		}
 
-		if err != nil && c.expectedErr == nil {
-			t.Errorf("Expected err to be nil but it was %q", err)
-		}
-
-		if c.expectedErr != nil {
-			if err.Error() != c.expectedErr.Error() {
-				t.Errorf("Expected err to be %q but it was %q", c.expectedErr, err)
-			}
-		}
+		require.NoError(t, err)
+		require.Equal(t, c.expectedGroupIdentifier, resGroupIdentifier)
 	}
 }

--- a/pkg/user/user_test.go
+++ b/pkg/user/user_test.go
@@ -12,33 +12,16 @@ import (
 	"github.com/xenitab/azad-kube-proxy/pkg/models"
 )
 
-type fakeAzureClient struct {
-	fakeError error
-}
-
-// GetUserGroups ...
-func (client *fakeAzureClient) GetUserGroups(ctx context.Context, objectID string, userType models.UserType) ([]models.Group, error) {
-	return nil, client.fakeError
-}
-
-// StartSyncGroups ...
-func (client *fakeAzureClient) StartSyncGroups(ctx context.Context, syncInterval time.Duration) (*time.Ticker, chan bool, error) {
-	return nil, nil, nil
-}
-
-// Valid ...
-func (client *fakeAzureClient) Valid(ctx context.Context) bool {
-	return true
-}
-
 func TestGetUser(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	config := config.Config{}
-	azureClient := &fakeAzureClient{
+	azureClient := &testFakeAzureClient{
 		fakeError: nil,
+		t:         t,
 	}
-	azureClientError := &fakeAzureClient{
+	azureClientError := &testFakeAzureClient{
 		fakeError: errors.New("Fake error"),
+		t:         t,
 	}
 
 	cases := []struct {
@@ -81,4 +64,30 @@ func TestGetUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, c.expectedUserType, user.Type)
 	}
+}
+
+type testFakeAzureClient struct {
+	fakeError error
+	t         *testing.T
+}
+
+// GetUserGroups ...
+func (client *testFakeAzureClient) GetUserGroups(ctx context.Context, objectID string, userType models.UserType) ([]models.Group, error) {
+	client.t.Helper()
+
+	return nil, client.fakeError
+}
+
+// StartSyncGroups ...
+func (client *testFakeAzureClient) StartSyncGroups(ctx context.Context, syncInterval time.Duration) (*time.Ticker, chan bool, error) {
+	client.t.Helper()
+
+	return nil, nil, nil
+}
+
+// Valid ...
+func (client *testFakeAzureClient) Valid(ctx context.Context) bool {
+	client.t.Helper()
+
+	return true
 }


### PR DESCRIPTION
This PR updates the tests to use `require` making them easier to read. While we're at it, we're also fixing up all the helpers making sure they are prefixed with `test` and executes `t.Helper()` in the beginning - this also makes it possible to add the linter `thelper`.