### PR TITLE
[Chore] Stop using kind action

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -42,12 +42,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.2.1
       - name: Set up KinD
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.11.1
-          image: kindest/node:v1.21.1
-      - name: Set up helm
-        uses: azure/setup-helm@v3.5
+        id: kind
+        run: |
+          kind create cluster --image=kindest/node:v1.25.3
       - name: Build and load (current arch)
         run: |
           docker buildx build --load -t ${{ env.NAME }}:${{ steps.prep.outputs.VERSION }} .


### PR DESCRIPTION
Kind is built in to ubuntu 22.04 now a days and the kind action will soon go out of support due to nodejs being to old.
Sadly that project isn't maintained any more so it's easier to stop using it all together. 